### PR TITLE
Fix integer underflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: perl
 perl:
-  - "5.14"
-  - "5.12"
+  - "5.20"
+  - "5.18"
 before_install: "cpanm --quiet --notest Module::Install Module::Install::Repository Module::Install::XSUtil Module::Install::AuthorTests"
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Changes
 =======
 
+0.00010 - Mar 1 2013
+    - No code change. Just a re-release of 0.00009
+
 0.00009 - Oct 20 2012
     - No code change
     - Upgrade to Module::Install 1.06

--- a/Changes
+++ b/Changes
@@ -1,6 +1,18 @@
 Changes
 =======
 
+0.00011 - Feb 18 2015
+    - The library now properly handles hashing binary data. Previously
+      it would expect NULL-terminated strings.
+
+    - Fixed a bug with the code segfaulting on some keys, e.g. the
+      pack "H*" versions of 161c6d14dae73a874ac0aa0017fb8340 and
+      37292b669dd8f7c952cf79ca0dc6c5d7
+
+      This was discovered "in the wild" in a system that deals with
+      billions of keys, htese keys just so happened to trigger a
+      segfault in the library due to how the binary search works.
+
 0.00010 - Mar 1 2013
     - No code change. Just a re-release of 0.00009
 

--- a/lib/Algorithm/ConsistentHash/Ketama.pm
+++ b/lib/Algorithm/ConsistentHash/Ketama.pm
@@ -5,7 +5,7 @@ use XSLoader;
 our $VERSION;
 
 BEGIN {
-    $VERSION = '0.00009';
+    $VERSION = '0.00011';
     XSLoader::load( __PACKAGE__, $VERSION );
 }
 

--- a/lib/Algorithm/ConsistentHash/Ketama.pm
+++ b/lib/Algorithm/ConsistentHash/Ketama.pm
@@ -49,7 +49,7 @@ Algorithm::ConsistentHash::Ketama - Ketama Consistent Hashing for Perl (XS)
     # $ketama = Algorithm::ConsistentHash::Ketama->new(
     #    use_hashfunc => Algorithm::ConsistentHash::Ketama::HASHFUNC2(),
     # )
-    # See "IMPORTANT NOTES FOR USERS OF 0.00009 AND BELOW"
+    # See "IMPORTANT NOTES FOR USERS OF 0.00011 AND BELOW"
 
     $ketama->add_bucket( $key1, $weight1 );
     $ketama->add_bucket( $key2, $weight2 );
@@ -108,7 +108,7 @@ recomputing the hash.
 Given a number, returns the label associated with that hash number. Only
 hashes returned by hash_with_hashnum are permissible.
 
-=head1 IMPORTANT NOTES FOR USERS OF 0.00009 AND BELOW
+=head1 IMPORTANT NOTES FOR USERS OF 0.00011 AND BELOW
 
 Prior to version 0.00010 of this module, there used be a integer underflow
 bug. which caused inconsistencies with other implementations of this algorithm.

--- a/t/003_dgryski.t
+++ b/t/003_dgryski.t
@@ -1,0 +1,36 @@
+#!perl
+
+use strict;
+use Test::More;
+
+# https://github.com/dgryski/go-ketama/commit/5fb0f7e85cb457c4cfb78bb892d02434d9f0620b
+
+use Algorithm::ConsistentHash::Ketama;
+
+# This is the old behavior
+subtest 'Old behavior' => sub {
+    my $ketama = Algorithm::ConsistentHash::Ketama->new();
+    $ketama->add_bucket( "r01", 100 );
+    $ketama->add_bucket( "r02", 100 );
+
+    for my $v (qw(37292b669dd8f7c952cf79ca0dc6c5d7 161c6d14dae73a874ac0aa0017fb8340)) {
+        my $key = $ketama->hash( pack "H*", $v );
+        is $key, "r01", "old behavior: should be r01";
+    }
+};
+
+# This is the new behavior
+subtest 'New behavior' => sub {
+    my $ketama = Algorithm::ConsistentHash::Ketama->new(
+        use_hashfunc => Algorithm::ConsistentHash::Ketama::HASHFUNC2(),
+    );
+    $ketama->add_bucket( "r01", 100 );
+    $ketama->add_bucket( "r02", 100 );
+
+    for my $v (qw(37292b669dd8f7c952cf79ca0dc6c5d7 161c6d14dae73a874ac0aa0017fb8340)) {
+        my $key = $ketama->hash( pack "H*", $v );
+        is $key, "r02", "new behavior: should be r02";
+    }
+};
+
+done_testing;

--- a/xs/Ketama.h
+++ b/xs/Ketama.h
@@ -19,12 +19,13 @@ typedef struct {
     unsigned int point;
 } PerlKetama_Continuum_Point;
 
-typedef struct {
+typedef struct __PerlKetama {
     unsigned int numbuckets;
     unsigned int totalweight;
     PerlKetama_Continuum_Point *continuum;
     unsigned int numpoints;
     PerlKetama_Bucket *buckets;
+    char *(*hashfunc)( struct __PerlKetama *, char *, STRLEN, unsigned int * );
 } PerlKetama;
 
 typedef int (*compfn)( const void*, const void* );

--- a/xs/Ketama.xs
+++ b/xs/Ketama.xs
@@ -296,11 +296,8 @@ PerlKetama_hash_internal2( PerlKetama *ketama, char *thing, STRLEN len, unsigned
 {
     unsigned int h;
     unsigned int highp;
-    unsigned int maxp  = 0,
-        lowp  = 0,
-        midp  = 0
-    ;
-    unsigned int midval, midval1;
+    unsigned int lowp;
+    unsigned int midp;
 
     if (ketama->numpoints == 0 && ketama->numbuckets > 0) {
         PERL_KETAMA_TRACE("Generating continuum");
@@ -312,9 +309,6 @@ PerlKetama_hash_internal2( PerlKetama *ketama, char *thing, STRLEN len, unsigned
         return NULL;
     }
 
-    highp = ketama->numpoints;
-    maxp  = highp;
-
     /* Accept either string OR hash number as input */
     if (thing != NULL) {
         h = PerlKetama_hash_string(thing, len);
@@ -324,36 +318,23 @@ PerlKetama_hash_internal2( PerlKetama *ketama, char *thing, STRLEN len, unsigned
         h = *thehash;
     }
 
-    while ( 1 ) {
-        midp = (int)( ( lowp+highp ) / 2 );
-        if ( midp <= 0 ) {
-            midp = maxp;
-        }
-        if ( midp >= maxp ) {
-            if ( midp == ketama->numpoints ) {
-                midp = 1;
-            } else {
-                midp = maxp;
-            }
+    lowp = 0;
+    highp = ketama->numpoints;
 
-            return ketama->continuum[midp - 1].bucket->label;
-        }
-        midval = ketama->continuum[midp].point;
-        midval1 = midp == 0 ? 0 : ketama->continuum[midp - 1].point;
-
-        if ( h <= midval && h > midval1 ) {
-            return ketama->continuum[midp].bucket->label;
-        }
-
-        if ( midval < h )
+    while (lowp < highp) {
+        midp = lowp + (highp - lowp) / 2;
+        if (ketama->continuum[midp].point > h) {
+            highp = midp;
+        } else {
             lowp = midp + 1;
-        else
-            highp = midp - 1;
-
-        if ( lowp > highp ) {
-            return ketama->continuum[0].bucket->label;
         }
     }
+
+    if (lowp >= ketama->numpoints) {
+       lowp = 0;
+    }
+
+    return ketama->continuum[lowp].bucket->label;
 }
 
 // This code exist because you might need to keep backwards compatibility


### PR DESCRIPTION
This change fixes the integer underflow reported in

https://github.com/dgryski/go-ketama/commit/5fb0f7e85cb457c4cfb78bb892d02434d9f0620bA

Because this changes the hashing for some keys and you may already
have important data spread using this rule, the original behavior
has been kept as the default behavior.

See the documentation on how to switch to the new behavior which
avoids the underflow